### PR TITLE
fix: missing server.Run() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ func main() {
 			InsertText:          strPtr("Hello"),
 		}}, nil
 	})
+
+	server.Run()
 }
 ```


### PR DESCRIPTION
while trying your library I noticed the missing `server.Run()`.

@TobiasYin also:
I noticed you didn't pick an open source license, yet.
Wether or not I can use this project in production depends on the [license you choose](https://choosealicense.com).