### PR TITLE
always use "2.0" as the jsonrpc version

### DIFF
--- a/jsonrpc/session.go
+++ b/jsonrpc/session.go
@@ -267,7 +267,12 @@ func (s *Session) mustWrite(data []byte) error {
 	return nil
 }
 func (s *Session) handlerResponse(id interface{}, result interface{}, err error) error {
-	resp := ResponseMessage{ID: id}
+	resp := ResponseMessage{
+		BaseMessage: BaseMessage{
+			Jsonrpc: "2.0",
+		},
+		ID: id,
+	}
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return err


### PR DESCRIPTION
Hi,

I'm trying to integrate this with [Helix](https://github.com/helix-editor/helix) but got this error:

```
{
  "jsonrpc": "",
  "id": 0,
  "result": {
    "capabilities": {
      "textDocumentSync": 1,
      "completionProvider": {
        "triggerCharacters": [
          "."
        ]
      }
    }
  },
  "error": null
}

Parse(Error("data did not match any variant of untagged enum ServerMessage", line: 0, column: 0))
```

and I think that we need to pass "2.0" as jsonrpc version in the response.

